### PR TITLE
fix(card): Avoid deforming the image

### DIFF
--- a/src/components/Card/Card.css
+++ b/src/components/Card/Card.css
@@ -43,6 +43,7 @@
   display: block;
   position: relative;
   border-radius: 50%;
+  object-fit: cover;
   width: var(--avatar-dim);
   height: var(--avatar-dim);
 }


### PR DESCRIPTION
Avoid deforming the image when the width/height ratio does not fit the given image.